### PR TITLE
Task/APPS-2668 — agencies as enums

### DIFF
--- a/src/components/timeline/CaseTimeline.js
+++ b/src/components/timeline/CaseTimeline.js
@@ -25,7 +25,6 @@ const {
   DATETIME_COMPLETED,
   EFFECTIVE_DATE,
   NOTES,
-  SOURCE,
   STATUS,
 } = PropertyTypes;
 const { CLOSED, REFERRAL } = CaseStatusConstants;
@@ -43,12 +42,18 @@ const TimelineContentWrapper = styled.div`
 `;
 
 type Props = {
+  agencyName :string;
   caseStatuses :List;
   referralRequest :?Map;
   staffMemberByStatusEKID :Map;
 };
 
-const CaseTimeline = ({ caseStatuses, referralRequest, staffMemberByStatusEKID } :Props) => (
+const CaseTimeline = ({
+  agencyName,
+  caseStatuses,
+  referralRequest,
+  staffMemberByStatusEKID,
+} :Props) => (
   <Timeline>
     {
       caseStatuses.map((caseStatus :Map) => {
@@ -63,7 +68,6 @@ const CaseTimeline = ({ caseStatuses, referralRequest, staffMemberByStatusEKID }
         }
 
         const staffMemberWhoRecordedStatus :Map = staffMemberByStatusEKID.get(caseStatusEKID, Map());
-        const referralSource = getPropertyValue(referralRequest, [SOURCE, 0]);
 
         return (
           <TimelineItem key={caseStatusEKID}>
@@ -78,7 +82,7 @@ const CaseTimeline = ({ caseStatuses, referralRequest, staffMemberByStatusEKID }
                   <Typography variant="overline">{status}</Typography>
                   <Typography variant="body1">
                     {status === CLOSED && description}
-                    {(status === REFERRAL && isDefined(referralRequest)) && referralSource}
+                    {(status === REFERRAL && isDefined(referralRequest)) && agencyName}
                     {(status !== CLOSED
                         && status !== REFERRAL
                         && !staffMemberWhoRecordedStatus.isEmpty())

--- a/src/containers/intake/IntakeForm.js
+++ b/src/containers/intake/IntakeForm.js
@@ -62,8 +62,9 @@ const {
   PROFILE,
   STAFF_MEMBERS,
 } = ProfileReduxConstants;
-const { REFERRAL, REFERRAL_REQUEST_NEIGHBOR_MAP } = ReferralReduxConstants;
+const { AGENCIES, REFERRAL, REFERRAL_REQUEST_NEIGHBOR_MAP } = ReferralReduxConstants;
 const {
+  AGENCY,
   CHARGES,
   CRC_CASE,
   FORM,
@@ -144,6 +145,13 @@ const IntakeForm = () => {
     charges,
     [NAME],
     ['properties', getPageSectionKey(1, 4), 'properties', getEntityAddressKey(0, CHARGES, NAME)]
+  );
+  const agencies :List = useSelector((store) => store.getIn([REFERRAL, AGENCIES], List()));
+  hydratedSchema = hydrateSchema(
+    hydratedSchema,
+    agencies,
+    [NAME],
+    ['properties', getPageSectionKey(1, 4), 'properties', getEntityAddressKey(0, AGENCY, NAME)]
   );
 
   const prepopulatedFormData = useMemo(() => populateFormData(

--- a/src/containers/intake/schemas/IntakeSchemas.js
+++ b/src/containers/intake/schemas/IntakeSchemas.js
@@ -12,6 +12,7 @@ const { OPENLATTICE_ID_FQN } = Constants;
 const { INTAKE_FORM } = FormConstants;
 const { INTAKE } = CaseStatusConstants;
 const {
+  AGENCY,
   CHARGES,
   CHARGE_EVENT,
   DA_CASE,
@@ -40,7 +41,6 @@ const {
   ORGANIZATION_NAME,
   PRONOUN,
   RACE,
-  SOURCE,
   SURNAME,
 } = PropertyTypes;
 
@@ -161,7 +161,7 @@ const dataSchema = {
           type: 'string',
           title: 'Officer Last Name',
         },
-        [getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE)]: {
+        [getEntityAddressKey(0, AGENCY, NAME)]: {
           type: 'string',
           title: 'Referring Agency',
         },
@@ -320,7 +320,7 @@ const uiSchema = {
     [getEntityAddressKey(0, OFFICERS, SURNAME)]: {
       classNames: 'column-span-4'
     },
-    [getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE)]: {
+    [getEntityAddressKey(0, AGENCY, NAME)]: {
       classNames: 'column-span-4'
     },
     [getEntityAddressKey(0, DA_CASE, DA_CASE_NUMBER)]: {

--- a/src/containers/intake/utils/IntakeUtils.js
+++ b/src/containers/intake/utils/IntakeUtils.js
@@ -10,6 +10,7 @@ import { EMPTY_VALUE, RoleConstants } from '../../profile/src/constants';
 
 const { VICTIM } = RoleConstants;
 const {
+  AGENCY,
   CHARGES,
   CHARGE_EVENT,
   DA_CASE,
@@ -31,7 +32,6 @@ const {
   ORGANIZATION_NAME,
   RACE,
   ROLE,
-  SOURCE,
   SURNAME,
 } = PropertyTypes;
 const { getEntityAddressKey, getPageSectionKey } = DataProcessingUtils;
@@ -56,9 +56,12 @@ const populateFormData = (
 ) :Object => {
 
   const referralRequestEKID :?UUID = getEntityKeyId(referralRequest);
-  const referringSource = getPropertyValue(referralRequest, [SOURCE, 0], EMPTY_VALUE);
   const datetimeOfReferral = getPropertyValue(referralRequest, [DATETIME_COMPLETED, 0], EMPTY_VALUE);
   const dateOfReferral = DateTime.fromISO(datetimeOfReferral).toISODate();
+
+  const agencyList = referralRequestNeighborMap.getIn([AGENCY, referralRequestEKID], List());
+  const agency :Map = agencyList.get(0, Map());
+  const agencyName = getPropertyValue(agency, [NAME, 0], EMPTY_VALUE);
 
   const officerList = referralRequestNeighborMap.getIn([OFFICERS, referralRequestEKID], List());
   const officer :Map = officerList.get(0, Map());
@@ -102,7 +105,7 @@ const populateFormData = (
       [getEntityAddressKey(0, REFERRAL_REQUEST, DATETIME_COMPLETED)]: dateOfReferral,
       [getEntityAddressKey(0, OFFICERS, GIVEN_NAME)]: officerFirstName,
       [getEntityAddressKey(0, OFFICERS, SURNAME)]: officerLastName,
-      [getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE)]: referringSource,
+      [getEntityAddressKey(0, AGENCY, NAME)]: agencyName,
       [getEntityAddressKey(0, DA_CASE, DA_CASE_NUMBER)]: daCaseNumber,
       [getEntityAddressKey(0, DA_CASE, CASE_NUMBER)]: caseNumber,
       [getEntityAddressKey(0, DA_CASE, GENERAL_DATETIME)]: dateOfIncident,

--- a/src/containers/profile/src/caseparticipation/CaseDetailsModal.js
+++ b/src/containers/profile/src/caseparticipation/CaseDetailsModal.js
@@ -26,7 +26,7 @@ import {
   ModalInnerWrapper,
 } from '../../../../components';
 import { AppTypes, PropertyTypes } from '../../../../core/edm/constants';
-import { APP_PATHS, ProfileReduxConstants } from '../../../../core/redux/constants';
+import { APP_PATHS, ProfileReduxConstants, ReferralReduxConstants } from '../../../../core/redux/constants';
 import { ADD_PEOPLE_TO_CASE, CASE_ID } from '../../../../core/router/Routes';
 import { goToRoute } from '../../../../core/router/RoutingActions';
 import { getPersonName } from '../../../../utils/people';
@@ -41,9 +41,20 @@ const {
   PROFILE,
   STAFF_MEMBER_BY_STATUS_EKID,
 } = ProfileReduxConstants;
+const { REFERRAL, REFERRAL_REQUEST_NEIGHBOR_MAP } = ReferralReduxConstants;
 const { NEUTRAL } = Colors;
-const { FORM, REFERRAL_REQUEST, STATUS } = AppTypes;
-const { DATETIME_ADMINISTERED, EFFECTIVE_DATE, ORGANIZATION_NAME } = PropertyTypes;
+const {
+  AGENCY,
+  FORM,
+  REFERRAL_REQUEST,
+  STATUS,
+} = AppTypes;
+const {
+  DATETIME_ADMINISTERED,
+  EFFECTIVE_DATE,
+  NAME,
+  ORGANIZATION_NAME,
+} = PropertyTypes;
 const { PEACEMAKER, RESPONDENT, VICTIM } = RoleConstants;
 const { CLOSED, RESOLUTION } = CaseStatusConstants;
 const { getEntityKeyId, getPropertyValue } = DataUtils;
@@ -110,6 +121,11 @@ const CaseDetailsModal = ({
     .sortBy((form :Map) => form.getIn([DATETIME_ADMINISTERED, 0])).reverse();
 
   const personCaseNeighborMap = useSelector((store) => store.getIn([PROFILE, PERSON_CASE_NEIGHBOR_MAP]));
+  const referralRequestNeighborMap = useSelector((store) => store.getIn([REFERRAL, REFERRAL_REQUEST_NEIGHBOR_MAP]));
+  const referralRequestEKID :?UUID = getEntityKeyId(referralRequest);
+  const agencyList = referralRequestNeighborMap.getIn([AGENCY, referralRequestEKID], List());
+  const agency :Map = agencyList.get(0, Map());
+  const agencyName = getPropertyValue(agency, [NAME, 0]);
 
   const respondentList :List = caseRoleMap.get(RESPONDENT, List());
   const victimList :List = caseRoleMap.get(VICTIM, List());
@@ -182,6 +198,7 @@ const CaseDetailsModal = ({
             </IconButton>
           </header>
           <CaseTimeline
+              agencyName={agencyName}
               caseStatuses={relevantStatuses}
               referralRequest={referralRequest}
               staffMemberByStatusEKID={staffMemberByStatusEKID} />

--- a/src/containers/referral/actions/index.js
+++ b/src/containers/referral/actions/index.js
@@ -2,6 +2,9 @@
 import { newRequestSequence } from 'redux-reqseq';
 import type { RequestSequence } from 'redux-reqseq';
 
+const GET_AGENCIES :'GET_AGENCIES' = 'GET_AGENCIES';
+const getAgencies :RequestSequence = newRequestSequence(GET_AGENCIES);
+
 const GET_CHARGES :'GET_CHARGES' = 'GET_CHARGES';
 const getCharges :RequestSequence = newRequestSequence(GET_CHARGES);
 
@@ -24,12 +27,14 @@ const SUBMIT_REFERRAL_FORM :'SUBMIT_REFERRAL_FORM' = 'SUBMIT_REFERRAL_FORM';
 const submitReferralForm :RequestSequence = newRequestSequence(SUBMIT_REFERRAL_FORM);
 
 export {
+  GET_AGENCIES,
   GET_CHARGES,
   GET_CRC_PEOPLE,
   GET_ORGANIZATIONS,
   GET_REFERRAL_REQUEST_NEIGHBORS,
   SELECT_REFERRAL_FORM,
   SUBMIT_REFERRAL_FORM,
+  getAgencies,
   getCRCPeople,
   getCharges,
   getOrganizations,

--- a/src/containers/referral/reducers/getAgenciesReducer.js
+++ b/src/containers/referral/reducers/getAgenciesReducer.js
@@ -1,0 +1,23 @@
+// @flow
+import { Map } from 'immutable';
+import { RequestStates } from 'redux-reqseq';
+import type { SequenceAction } from 'redux-reqseq';
+
+import { REQUEST_STATE, ReferralReduxConstants } from '../../../core/redux/constants';
+import { GET_AGENCIES, getAgencies } from '../actions';
+
+const { AGENCIES } = ReferralReduxConstants;
+
+export default function reducer(state :Map, action :SequenceAction) {
+
+  return getAgencies.reducer(state, action, {
+    REQUEST: () => state
+      .setIn([GET_AGENCIES, REQUEST_STATE], RequestStates.PENDING)
+      .setIn([GET_AGENCIES, action.id], action),
+    SUCCESS: () => state
+      .set(AGENCIES, action.value)
+      .setIn([GET_AGENCIES, REQUEST_STATE], RequestStates.SUCCESS),
+    FAILURE: () => state.setIn([GET_AGENCIES, REQUEST_STATE], RequestStates.FAILURE),
+    FINALLY: () => state.deleteIn([GET_AGENCIES, action.id]),
+  });
+}

--- a/src/containers/referral/reducers/index.js
+++ b/src/containers/referral/reducers/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { List, Map, fromJS } from 'immutable';
 
+import getAgenciesReducer from './getAgenciesReducer';
 import getCRCPeopleReducer from './getCRCPeopleReducer';
 import getChargesReducer from './getChargesReducer';
 import getOrganizationsReducer from './getOrganizationsReducer';
@@ -12,12 +13,14 @@ import { RESET_REQUEST_STATE } from '../../../core/redux/actions';
 import { RS_INITIAL_STATE, ReferralReduxConstants } from '../../../core/redux/constants';
 import { resetRequestStateReducer } from '../../../core/redux/reducers';
 import {
+  GET_AGENCIES,
   GET_CHARGES,
   GET_CRC_PEOPLE,
   GET_ORGANIZATIONS,
   GET_REFERRAL_REQUEST_NEIGHBORS,
   SELECT_REFERRAL_FORM,
   SUBMIT_REFERRAL_FORM,
+  getAgencies,
   getCRCPeople,
   getCharges,
   getOrganizations,
@@ -26,6 +29,7 @@ import {
 } from '../actions';
 
 const {
+  AGENCIES,
   CHARGES,
   CRC_ORGANIZATIONS,
   CRC_PEOPLE,
@@ -35,12 +39,14 @@ const {
 
 const INITIAL_STATE :Map = fromJS({
   // actions
+  [GET_AGENCIES]: RS_INITIAL_STATE,
   [GET_CHARGES]: RS_INITIAL_STATE,
   [GET_CRC_PEOPLE]: RS_INITIAL_STATE,
   [GET_ORGANIZATIONS]: RS_INITIAL_STATE,
   [GET_REFERRAL_REQUEST_NEIGHBORS]: RS_INITIAL_STATE,
   [SUBMIT_REFERRAL_FORM]: RS_INITIAL_STATE,
   // data
+  [AGENCIES]: List(),
   [CHARGES]: List(),
   [CRC_ORGANIZATIONS]: List(),
   [CRC_PEOPLE]: List(),
@@ -59,6 +65,9 @@ export default function profileReducer(state :Map = INITIAL_STATE, action :Objec
     case SELECT_REFERRAL_FORM: {
       return selectReferralFormReducer(state, action);
     }
+
+    case getAgencies.case(action.type):
+      return getAgenciesReducer(state, action);
 
     case getCharges.case(action.type):
       return getChargesReducer(state, action);

--- a/src/containers/referral/sagas/getAgencies.js
+++ b/src/containers/referral/sagas/getAgencies.js
@@ -1,0 +1,62 @@
+// @flow
+import {
+  call,
+  put,
+  select,
+  takeEvery,
+} from '@redux-saga/core/effects';
+import { List, fromJS } from 'immutable';
+import { DataApiActions, DataApiSagas } from 'lattice-sagas';
+import { Logger } from 'lattice-utils';
+import type { Saga } from '@redux-saga/core';
+import type { UUID } from 'lattice';
+import type { SequenceAction } from 'redux-reqseq';
+
+import { AppTypes } from '../../../core/edm/constants';
+import { selectEntitySetId } from '../../../core/redux/selectors';
+import { GET_AGENCIES, getAgencies } from '../actions';
+
+const { getEntitySetData } = DataApiActions;
+const { getEntitySetDataWorker } = DataApiSagas;
+const { AGENCY } = AppTypes;
+
+const LOG = new Logger('ReferralSagas');
+
+function* getAgenciesWorker(action :SequenceAction) :Saga<*> {
+
+  const { id } = action;
+  const workerResponse = {};
+
+  try {
+    yield put(getAgencies.request(id));
+
+    const agencyESID :UUID = yield select(selectEntitySetId(AGENCY));
+    const response = yield call(
+      getEntitySetDataWorker, getEntitySetData({ entitySetId: agencyESID })
+    );
+    if (response.error) throw response.error;
+    const agencies :List = fromJS(response.data);
+
+    workerResponse.data = agencies;
+    yield put(getAgencies.success(id, agencies));
+  }
+  catch (error) {
+    workerResponse.error = error;
+    LOG.error(action.type, error);
+    yield put(getAgencies.failure(id, error));
+  }
+  finally {
+    yield put(getAgencies.finally(id));
+  }
+  return workerResponse;
+}
+
+function* getAgenciesWatcher() :Saga<*> {
+
+  yield takeEvery(GET_AGENCIES, getAgenciesWorker);
+}
+
+export {
+  getAgenciesWatcher,
+  getAgenciesWorker,
+};

--- a/src/containers/referral/sagas/getReferralRequestNeighbors.js
+++ b/src/containers/referral/sagas/getReferralRequestNeighbors.js
@@ -21,6 +21,7 @@ import { GET_REFERRAL_REQUEST_NEIGHBORS, getReferralRequestNeighbors } from '../
 
 const { FQN } = Models;
 const {
+  AGENCY,
   DA_CASE,
   OFFENSE,
   OFFICERS,
@@ -40,6 +41,7 @@ function* getReferralRequestNeighborsWorker(action :SequenceAction) :Saga<*> {
     const { value } = action;
     const referralRequestEKIDs :UUID[] = value;
 
+    const agencyESID :UUID = yield select(selectEntitySetId(AGENCY));
     const daCaseESID :UUID = yield select(selectEntitySetId(DA_CASE));
     const offenseESID :UUID = yield select(selectEntitySetId(OFFENSE));
     const officersESID :UUID = yield select(selectEntitySetId(OFFICERS));
@@ -47,7 +49,7 @@ function* getReferralRequestNeighborsWorker(action :SequenceAction) :Saga<*> {
 
     const filter = {
       entityKeyIds: referralRequestEKIDs,
-      destinationEntitySetIds: [officersESID],
+      destinationEntitySetIds: [agencyESID, officersESID],
       sourceEntitySetIds: [daCaseESID, offenseESID],
     };
 

--- a/src/containers/referral/sagas/index.js
+++ b/src/containers/referral/sagas/index.js
@@ -1,4 +1,5 @@
 // @flow
+export * from './getAgencies';
 export * from './getCRCPeople';
 export * from './getCharges';
 export * from './getOrganizations';

--- a/src/containers/referral/schemas/ReferralSchemas.js
+++ b/src/containers/referral/schemas/ReferralSchemas.js
@@ -12,6 +12,7 @@ const { OPENLATTICE_ID_FQN } = Constants;
 const { REFERRAL_FORM } = FormConstants;
 const { REFERRAL } = CaseStatusConstants;
 const {
+  AGENCY,
   CHARGES,
   CHARGE_EVENT,
   CRC_CASE,
@@ -42,7 +43,6 @@ const {
   ORGANIZATION_NAME,
   PRONOUN,
   RACE,
-  SOURCE,
   SURNAME,
 } = PropertyTypes;
 
@@ -69,9 +69,11 @@ const dataSchema = {
           type: 'string',
           title: 'Officer Last Name',
         },
-        [getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE)]: {
+        [getEntityAddressKey(0, AGENCY, NAME)]: {
           type: 'string',
           title: 'Referring Agency',
+          enum: [],
+          enumNames: []
         },
         [getEntityAddressKey(0, DA_CASE, DA_CASE_NUMBER)]: {
           type: 'string',
@@ -101,7 +103,7 @@ const dataSchema = {
       required: [
         getEntityAddressKey(0, REFERRAL_REQUEST, DATETIME_COMPLETED),
         getEntityAddressKey(0, DA_CASE, CASE_NUMBER),
-        getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE),
+        getEntityAddressKey(0, AGENCY, NAME),
       ]
     },
     [getPageSectionKey(1, 2)]: {
@@ -261,8 +263,9 @@ const uiSchema = {
     [getEntityAddressKey(0, OFFICERS, SURNAME)]: {
       classNames: 'column-span-4'
     },
-    [getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE)]: {
-      classNames: 'column-span-4'
+    [getEntityAddressKey(0, AGENCY, NAME)]: {
+      classNames: 'column-span-4',
+      'ui:options': { creatable: true }
     },
     [getEntityAddressKey(0, DA_CASE, DA_CASE_NUMBER)]: {
       classNames: 'column-span-4'

--- a/src/containers/referral/utils/CompletedReferralUtils.js
+++ b/src/containers/referral/utils/CompletedReferralUtils.js
@@ -13,6 +13,7 @@ import { EMPTY_VALUE, RoleConstants } from '../../profile/src/constants';
 const { OPENLATTICE_ID_FQN } = Constants;
 const { VICTIM } = RoleConstants;
 const {
+  AGENCY,
   CHARGES,
   CHARGE_EVENT,
   CRC_CASE,
@@ -38,7 +39,6 @@ const {
   ORGANIZATION_NAME,
   RACE,
   ROLE,
-  SOURCE,
   SURNAME,
 } = PropertyTypes;
 const { getEntityAddressKey, getPageSectionKey } = DataProcessingUtils;
@@ -62,9 +62,12 @@ const populateFormData = (
   const referralRequestList :List = formNeighborMap.getIn([formEKID, REFERRAL_REQUEST], List());
   const referralRequest :Map = referralRequestList.get(0, Map());
   const referralRequestEKID :?UUID = getEntityKeyId(referralRequest);
-  const referringSource = getPropertyValue(referralRequest, [SOURCE, 0], EMPTY_VALUE);
   const datetimeOfReferral = getPropertyValue(referralRequest, [DATETIME_COMPLETED, 0], EMPTY_VALUE);
   const dateOfReferral = DateTime.fromISO(datetimeOfReferral).toISODate();
+
+  const agencyList = referralRequestNeighborMap.getIn([AGENCY, referralRequestEKID], List());
+  const agency :Map = agencyList.get(0, Map());
+  const agencyName = getPropertyValue(agency, [NAME, 0], EMPTY_VALUE);
 
   const officerList = referralRequestNeighborMap.getIn([OFFICERS, referralRequestEKID], List());
   const officer :Map = officerList.get(0, Map());
@@ -125,7 +128,7 @@ const populateFormData = (
       [getEntityAddressKey(0, REFERRAL_REQUEST, DATETIME_COMPLETED)]: dateOfReferral,
       [getEntityAddressKey(0, OFFICERS, GIVEN_NAME)]: officerFirstName,
       [getEntityAddressKey(0, OFFICERS, SURNAME)]: officerLastName,
-      [getEntityAddressKey(0, REFERRAL_REQUEST, SOURCE)]: referringSource,
+      [getEntityAddressKey(0, AGENCY, NAME)]: agencyName,
       [getEntityAddressKey(0, DA_CASE, DA_CASE_NUMBER)]: daCaseNumber,
       [getEntityAddressKey(0, DA_CASE, CASE_NUMBER)]: caseNumber,
       [getEntityAddressKey(0, DA_CASE, GENERAL_DATETIME)]: dateOfIncident,

--- a/src/containers/referral/utils/ReferralFormUtils.js
+++ b/src/containers/referral/utils/ReferralFormUtils.js
@@ -20,6 +20,7 @@ import { RoleConstants } from '../../profile/src/constants';
 
 const { OPENLATTICE_ID_FQN } = Constants;
 const {
+  AGENCY,
   APPEARS_IN,
   CHARGES,
   CHARGE_EVENT,
@@ -112,6 +113,33 @@ const updateFormWithCharges = (formData :Object, charges :List) => {
     updatedFormData = removeIn(updatedFormData, chargeEventDatePath);
   }
   return { selectedChargeEKID, updatedFormData };
+};
+
+/*
+ * ReferralFormUtils.updateFormWithAgency
+ */
+
+const updateFormWithAgency = (formData :Object, agencies :List) => {
+
+  let updatedFormData = formData;
+
+  const agencyEKIDs = agencies.map((agency :Map) => getEntityKeyId(agency));
+
+  const page1Section1 = getPageSectionKey(1, 1);
+  const agencyNamePath = [page1Section1, getEntityAddressKey(0, AGENCY, NAME)];
+
+  const agencySelected = getIn(updatedFormData, agencyNamePath);
+  let selectedAgencyEKID = '';
+  if (isDefined(agencySelected)) {
+    if (isValidUUID(agencySelected) && agencyEKIDs.includes(agencySelected)) {
+      updatedFormData = removeIn(updatedFormData, agencyNamePath);
+      selectedAgencyEKID = agencySelected;
+    }
+  }
+  else {
+    updatedFormData = removeIn(updatedFormData, agencyNamePath);
+  }
+  return { selectedAgencyEKID, updatedFormData };
 };
 
 /*
@@ -253,5 +281,6 @@ export {
   getStaffInformation,
   getVictimAssociations,
   getVictimInformation,
+  updateFormWithAgency,
   updateFormWithCharges,
 };

--- a/src/core/redux/constants/ReferralReduxConstants.js
+++ b/src/core/redux/constants/ReferralReduxConstants.js
@@ -1,4 +1,5 @@
 // @flow
+const AGENCIES :'agencies' = 'agencies';
 const CHARGES :'charges' = 'charges';
 const CRC_ORGANIZATIONS :'crcOrganizations' = 'crcOrganizations';
 const CRC_PEOPLE :'crcPeople' = 'crcPeople';
@@ -7,6 +8,7 @@ const REFERRAL_REQUEST_NEIGHBOR_MAP :'referralRequestNeighborMap' = 'referralReq
 const SELECTED_REFERRAL_FORM :'selectedReferralForm' = 'selectedReferralForm';
 
 export {
+  AGENCIES,
   CHARGES,
   CRC_ORGANIZATIONS,
   CRC_PEOPLE,

--- a/src/core/sagas/Sagas.js
+++ b/src/core/sagas/Sagas.js
@@ -62,6 +62,7 @@ export default function* sagas() :Saga<*> {
     fork(ProfileSagas.submitContactWatcher),
 
     // ReferralSagas
+    fork(ReferralSagas.getAgenciesWatcher),
     fork(ReferralSagas.getCRCPeopleWatcher),
     fork(ReferralSagas.getChargesWatcher),
     fork(ReferralSagas.getOrganizationsWatcher),


### PR DESCRIPTION
Instead of saving the agency name on `ol.referralrequest` in the `ol.source` property, save each agency as its own entity in the `ol.agency` entity set.

![06dc9d98474033d2880dc6001474fc0a](https://user-images.githubusercontent.com/32921059/102640871-c2ecf480-4120-11eb-92f1-9d00dd3c7063.gif)
