### PR TITLE
Task/apps 2746 — da case number default

### DIFF
--- a/src/containers/downloads/utils/index.js
+++ b/src/containers/downloads/utils/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as DownloadReferralsUtils from './DownloadReferralsUtils';
 
+/* eslint-disable import/prefer-default-export */
 export {
   DownloadReferralsUtils,
 };

--- a/src/containers/intake/IntakeForm.js
+++ b/src/containers/intake/IntakeForm.js
@@ -66,6 +66,7 @@ const {
   AGENCY,
   CHARGES,
   CRC_CASE,
+  DA_CASE,
   FORM,
   HAS,
   PEOPLE,
@@ -78,6 +79,7 @@ const {
 } = AppTypes;
 const {
   DATETIME_ADMINISTERED,
+  DA_CASE_NUMBER,
   EFFECTIVE_DATE,
   GIVEN_NAME,
   NAME,
@@ -117,14 +119,19 @@ const IntakeForm = () => {
   const referralRequest = personCaseNeighborMap.getIn([REFERRAL_REQUEST, selectedCase, 0], Map());
   const referralRequestNeighborMap :Map = useSelector((store) => store
     .getIn([REFERRAL, REFERRAL_REQUEST_NEIGHBOR_MAP]));
+  const daCasesByReferralRequestEKID :Map = referralRequestNeighborMap.get(DA_CASE, Map());
 
   const crcCases :List = personNeighborMap.get(CRC_CASE, List());
   const crcOptions = crcCases.map((crcCase :Map) => {
     const crcCaseEKID :?UUID = getEntityKeyId(crcCase);
-    const crcCaseNumber = getPropertyValue(crcCase, [NOTES, 0]);
+    const crcCaseNumber :string = getPropertyValue(crcCase, [NOTES, 0]);
     const respondent :Map = personCaseNeighborMap.getIn([ROLE, crcCaseEKID, RESPONDENT, 0], Map());
-    const respondentName = getPersonName(respondent);
-    const caseIdentifier = `${crcCaseNumber} - ${respondentName}`;
+    const respondentName :string = getPersonName(respondent);
+    const caseReferralRequest :Map = personCaseNeighborMap.getIn([REFERRAL_REQUEST, crcCaseEKID, 0], Map());
+    const caseReferralRequestEKID :?UUID = getEntityKeyId(caseReferralRequest);
+    const daCase :Map = daCasesByReferralRequestEKID.getIn([caseReferralRequestEKID, 0], Map());
+    const daCaseNumber :string = getPropertyValue(daCase, [DA_CASE_NUMBER, 0]);
+    const caseIdentifier = `${daCaseNumber || crcCaseNumber} - ${respondentName}`;
     return {
       label: caseIdentifier,
       value: crcCaseEKID,

--- a/src/utils/form/formatCasesForDropdown.js
+++ b/src/utils/form/formatCasesForDropdown.js
@@ -1,0 +1,41 @@
+// @flow
+import { List, Map } from 'immutable';
+import { DataUtils } from 'lattice-utils';
+import type { UUID } from 'lattice';
+
+import { RoleConstants } from '../../containers/profile/src/constants';
+import { AppTypes, PropertyTypes } from '../../core/edm/constants';
+import { getPersonName } from '../people';
+
+const { RESPONDENT } = RoleConstants;
+const { DA_CASE } = AppTypes;
+const { DA_CASE_NUMBER, NOTES, SURNAME } = PropertyTypes;
+const { getEntityKeyId, getPropertyValue } = DataUtils;
+
+export default function formatCasesForDropdown(
+  personCases :List,
+  caseRoleMap :Map,
+  referralRequestsByCRCCaseEKID :Map,
+  referralRequestNeighborMap :Map
+) {
+
+  return personCases.map((personCase :Map) => {
+    const roles = caseRoleMap.get(getEntityKeyId(personCase));
+    const respondentPerson = roles.getIn([RESPONDENT, 0], Map());
+    const respondentPersonName = getPersonName(respondentPerson);
+    // doesn't matter what property type to save respondent name under; just need one for hydrateSchema
+    let mappedPersonCase = personCase.set(SURNAME, List([`- ${respondentPersonName}`]));
+
+    const crcCaseEKID :?UUID = getEntityKeyId(personCase);
+    const referralRequest :Map = referralRequestsByCRCCaseEKID.getIn([crcCaseEKID, 0], Map());
+    const referralRequestEKID :?UUID = getEntityKeyId(referralRequest);
+    const daCase :Map = referralRequestNeighborMap.getIn([DA_CASE, referralRequestEKID, 0], Map());
+    const daCaseNumber = getPropertyValue(daCase, [DA_CASE_NUMBER, 0]);
+    if (daCaseNumber) {
+      // reset case number to be DA case number because that should be the default
+      mappedPersonCase = mappedPersonCase.set(NOTES, List([daCaseNumber]));
+    }
+
+    return mappedPersonCase;
+  });
+}

--- a/src/utils/form/index.js
+++ b/src/utils/form/index.js
@@ -2,6 +2,8 @@
 import { hydrateSchema } from './hydrateSchema';
 import { updateFormWithDateAsDateTime } from './updateFormWithDateAsDateTime';
 
+export { default as formatCasesForDropdown } from './formatCasesForDropdown';
+
 export {
   hydrateSchema,
   updateFormWithDateAsDateTime,


### PR DESCRIPTION
users want to show the DA case number by default for a case, and if there is no DA case number, show the law enforcement case number (which is what is currently being shown).

![Screen Shot 2021-01-29 at 1 34 44 PM](https://user-images.githubusercontent.com/32921059/106329710-cb177400-6236-11eb-9150-3fb454b5827b.png)
vs.
![Screen Shot 2021-01-29 at 1 34 53 PM](https://user-images.githubusercontent.com/32921059/106329728-d4084580-6236-11eb-9ff7-c997505a4897.png)


dropdowns show the right case number too:
![Screen Shot 2021-01-29 at 1 34 29 PM](https://user-images.githubusercontent.com/32921059/106329738-d79bcc80-6236-11eb-9371-1cfd0e5e3be7.png)
