### PR TITLE
update lockfileVersion from 1 to 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@openlattice/lattice-community-restorative-court",
   "version": "0.7.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "dependencies": {
     "@babel/cli": {


### PR DESCRIPTION
package-lock conflict from develop -> master is just the `lockfileVersion` number, which on develop, is 2, and on master, is 1. should ultimately be 2. attempting to solve this conflict by just making the change to master first to get rid of the conflict between develop and master.